### PR TITLE
Regenerate the provider documentation to remove ksoc_account_id

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,5 @@ provider "ksoc" {}
 ### Required
 
 - `access_key_id` (String, Sensitive) Ksoc Customer Access ID
-- `ksoc_account_id` (String, Sensitive) Customer Ksoc account ID
 - `ksoc_api_url` (String) Ksoc API to target
 - `secret_key` (String, Sensitive) Ksoc Customer Secret Key

--- a/examples/resources/aws_register/main.tf
+++ b/examples/resources/aws_register/main.tf
@@ -4,5 +4,4 @@ resource "ksoc_aws_register" "this" {
   access_key_id         = "ksoc_access_key"
   secret_key            = "ksoc_secret_key"
   aws_account_id        = "aws_account_id"
-  ksoc_account_id       = "ksoc_account_id"
 }


### PR DESCRIPTION
Remove ksoc_account_id from the generated documentation and provider example